### PR TITLE
継承クラスのinitialize修正の場合の例

### DIFF
--- a/test0715_2.rb
+++ b/test0715_2.rb
@@ -14,6 +14,11 @@ end
 class TokyoHuang < Huang
     attr_accessor :city
 
+    def initialize(name, age, city)
+      super(name, age)
+      @city=city
+    end
+
     def sencond(city)
         @city = city
     end


### PR DESCRIPTION
修正コードの例、その２です。

なお、このPRはブランチからブランチしていてPRも元のブランチにってなってますがこうなるとこのPRをマージし終わらないとmasterへのマスターにコードの取り残しが出るという具合に管理が厄介になります。
ブランチからブランチするなというのはそういう風にややこしくなるからって訳です。